### PR TITLE
Add error handling for 503 and network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+
+/.idea/*
+/icon_cache/*

--- a/sync_achievements.pygame
+++ b/sync_achievements.pygame
@@ -20,7 +20,15 @@
 # License, or (at your option) any later version.
 # 
 ###
+import json
+import os
+import sys
 
+import pygame
+import pygame.freetype
+import requests
+
+# Global variables
 USERNAME_OVERRIDE = 'ENTER_CREDENTIALS_HERE'
 PASSWORD_OVERRIDE = 'ENTER_CREDENTIALS_HERE'
 
@@ -28,21 +36,13 @@ SCREENSHOTS_DIRECTORY = "/userdata/screenshots/"
 # batocera.conf is ignored if the overrides above are used
 BATOCERA_CONF_LOCATION = '/userdata/system/batocera.conf'
 
-import pygame
-import pygame.freetype
-import sys
-import requests
-import json
-import time 
-import os
-import subprocess
 
 ENABLE_DEBUG_STRING = True
 pygame.init()
 WINDOW_SURFACE = pygame.HWSURFACE | pygame.DOUBLEBUF
 FONT_SIZE = 40
 FONT = pygame.font.SysFont(None, FONT_SIZE)
-FONT_SMALL = pygame.font.SysFont(None, FONT_SIZE//2)
+FONT_SMALL = pygame.font.SysFont(None, FONT_SIZE // 2)
 TEXT_COLOR = 'black'
 TEXT_COLOR_ACTIVE = (50, 75, 100)
 TEXT_COLOR_UNLOCKED = (0, 100, 0)
@@ -58,6 +58,7 @@ ICON_CACHE_DIR = 'icon_cache'
 if not os.path.exists(ICON_CACHE_DIR):
     os.makedirs(ICON_CACHE_DIR)
 
+
 class Icon:
     def __init__(self, state, cheevo_id, locked):
         self.cheevo_id = cheevo_id
@@ -67,8 +68,10 @@ class Icon:
     def get(self):
         return self.state.get_cheevo_icon(self.cheevo_id, self.locked)
 
+
 class Button:
-    def __init__(self, text, pos, fonts, base_color, hovering_color, hover_bg_color=None, lineheight=30, centered=True, icon=None, hoverbox=None):
+    def __init__(self, text, pos, fonts, base_color, hovering_color, hover_bg_color=None, lineheight=30, centered=True,
+                 icon=None, hoverbox=None):
         self.text = text
         self.pos = pos
         self.fonts = [x for x in fonts]
@@ -104,7 +107,7 @@ class Button:
             screen.blit(self.icon.get(), self.pos)
         for i in range(len(self.rendered_lines)):
             screen.blit(self.rendered_lines[i], self.render_rects[i])
-    
+
     def set_hovering(self, is_hovered):
         self.hovered = is_hovered
         self.color = self.hovering_color if is_hovered else self.base_color
@@ -126,7 +129,7 @@ class Button:
                 rect = rendered_text.get_rect(topleft=(self.textpos[0], self.textpos[1] + i * self.lineheight))
             self.rendered_lines.append(rendered_text)
             self.render_rects.append(rect)
-            
+
 
 def render_text(text, pos, font, color, centered=False):
     rendered_text = font.render(text, True, color)
@@ -155,7 +158,7 @@ class ErrorScreen:
     def render(self):
         for i, line in enumerate(self.error_message):
             if len(line) > 0:
-                render_text(line, (15, 75+20*i), FONT_SMALL, TEXT_COLOR)
+                render_text(line, (15, 75 + 20 * i), FONT_SMALL, TEXT_COLOR)
 
         pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 0), (640, 50)))
         pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 425), (640, 55)))
@@ -165,8 +168,10 @@ class ErrorScreen:
 class MainMenu:
     def __init__(self, state):
         self.state = state
-        self.start_button = Button(["Synchronize Achievements"], (320, 200), [FONT], TEXT_COLOR, TEXT_COLOR_ACTIVE, hover_bg_color=HOVER_BG_COLOR)
-        self.exit_button = Button(["Exit"], (320, 270), [FONT], TEXT_COLOR, TEXT_COLOR_ACTIVE, hover_bg_color=HOVER_BG_COLOR)
+        self.start_button = Button(["Synchronize Achievements"], (320, 200), [FONT], TEXT_COLOR, TEXT_COLOR_ACTIVE,
+                                   hover_bg_color=HOVER_BG_COLOR)
+        self.exit_button = Button(["Exit"], (320, 270), [FONT], TEXT_COLOR, TEXT_COLOR_ACTIVE,
+                                  hover_bg_color=HOVER_BG_COLOR)
         self.selected_button = self.start_button
 
     def handle_events(self):
@@ -183,7 +188,8 @@ class MainMenu:
                     if self.selected_button == self.start_button:
                         print(f'successfully uploaded achievements:')
                         print(self.state.get_uploaded_achievements(force_reload=True))
-                        self.state.unmatched_achievements = [x for x in self.state.get_unlocked_achievements() if x not in self.state.get_uploaded_achievements()]
+                        self.state.unmatched_achievements = [x for x in self.state.get_unlocked_achievements() if
+                                                             x not in self.state.get_uploaded_achievements()]
                         self.state.current_state = "SYNC_CHEEVOS"
                         return
                     elif self.selected_button == self.exit_button:
@@ -200,6 +206,7 @@ class MainMenu:
         pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 425), (640, 55)))
         render_text("Use DPAD to navigate", (15, 435), FONT_SMALL, TEXT_COLOR_LIGHT)
         render_text("A to select", (15, 455), FONT_SMALL, TEXT_COLOR_LIGHT)
+
 
 class ScrollCheevos:
     def __init__(self, state):
@@ -224,7 +231,8 @@ class ScrollCheevos:
         for achievement in self.state.get_unlocked_achievements():
             if achievement in self.state.get_uploaded_achievements():
                 color = TEXT_COLOR_UNLOCKED
-                cheevostring = f'{achievement:07d}: {self.state.get_uploaded_achievements()[achievement]["Title"]} ({self.state.get_uploaded_achievements()[achievement]["GameTitle"]})'
+                cheevostring = f'{achievement:07d}: {self.state.get_uploaded_achievements()[achievement]["Title"]} ' \
+                               f'({self.state.get_uploaded_achievements()[achievement]["GameTitle"]})'
             else:
                 color = TEXT_COLOR_NOT_UPLOADED
                 cheevostring = f'!!!!!! {achievement:07d} !!!!!!'
@@ -281,8 +289,10 @@ class SyncAchievements:
             no_button = yes_button
         else:
             questiontext = "Send unlock request?"
-            yes_button = Button(["YES"], (270, 300), [dialog_font], TEXT_COLOR, TEXT_COLOR_ACTIVE, centered=True, hover_bg_color=HOVER_BG_COLOR, hoverbox=(-35,-20,70,40))
-            no_button = Button(["NO"], (360, 300), [dialog_font], TEXT_COLOR, TEXT_COLOR_ACTIVE, centered=True, hover_bg_color=HOVER_BG_COLOR, hoverbox=(-35,-20,70,40))
+            yes_button = Button(["YES"], (270, 300), [dialog_font], TEXT_COLOR, TEXT_COLOR_ACTIVE, centered=True,
+                                hover_bg_color=HOVER_BG_COLOR, hoverbox=(-35, -20, 70, 40))
+            no_button = Button(["NO"], (360, 300), [dialog_font], TEXT_COLOR, TEXT_COLOR_ACTIVE, centered=True,
+                               hover_bg_color=HOVER_BG_COLOR, hoverbox=(-35, -20, 70, 40))
         selected_dialog_button = yes_button
 
         while True:
@@ -320,7 +330,7 @@ class SyncAchievements:
             pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 425), (640, 55)))
             render_text("Use DPAD to navigate", (15, 435), FONT_SMALL, TEXT_COLOR_LIGHT)
             render_text("A to select, B to return", (15, 455), FONT_SMALL, TEXT_COLOR_LIGHT)
-            
+
             cheevo_button.update(SCREEN)
             yes_button.update(SCREEN)
             no_button.update(SCREEN)
@@ -330,7 +340,7 @@ class SyncAchievements:
 
     def render(self):
         SCREEN.fill(BACKGROUND_COLOR)
-        
+
         if len(self.state.unmatched_achievements) > 0:
             pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 0), (640, 50)))
             render_text('Found missing achievements:', (10, 10), FONT, TEXT_COLOR_LIGHT)
@@ -347,7 +357,8 @@ class SyncAchievements:
             button_icon = Icon(self.state, achievement, locked=(not is_newly_unlocked))
             text_color = TEXT_COLOR_UNLOCKED if is_newly_unlocked else TEXT_COLOR
             highlight_color = TEXT_COLOR_UNLOCKED if is_newly_unlocked else TEXT_COLOR_ACTIVE
-            button = Button(button_text, (20, y_offset), [FONT, FONT_SMALL], text_color, highlight_color, centered=False, icon=button_icon, hover_bg_color=HOVER_BG_COLOR)
+            button = Button(button_text, (20, y_offset), [FONT, FONT_SMALL], text_color, highlight_color,
+                            centered=False, icon=button_icon, hover_bg_color=HOVER_BG_COLOR)
             button.cheevo_id = achievement
             self.buttons.append(button)
             y_offset += 70
@@ -356,7 +367,7 @@ class SyncAchievements:
 
         for i, button in enumerate(self.buttons):
             button.set_hovering(i == self.selected_button_index)
-            if button.pos[1] > 55 and button.pos[1] < self.max_ypos:
+            if 55 < button.pos[1] < self.max_ypos:
                 button.update(SCREEN)
 
         pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 425), (640, 55)))
@@ -412,41 +423,47 @@ class ListAchievements:
 
     def render(self):
         SCREEN.fill(BACKGROUND_COLOR)
-        
+
         pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 0), (640, 50)))
-        render_text('All achievements synchronized', (10, 10), FONT, TEXT_COLOR_LIGHT)
+        try:
+            y_offset = 130 + self.scroll_y
+            self.buttons = []
+            for achievement in self.state.get_uploaded_achievements():
+                ach_title = self.state.get_uploaded_achievements()[achievement]["Title"]
+                game_title = self.state.get_uploaded_achievements()[achievement]["GameTitle"]
+                button_text = [ach_title, game_title]
+                button_icon = Icon(self.state, achievement, locked=False)
+                text_color = TEXT_COLOR_UNLOCKED
+                highlight_color = TEXT_COLOR_UNLOCKED
+                button = Button(button_text, (20, y_offset), [FONT, FONT_SMALL], text_color, highlight_color,
+                                centered=False, icon=button_icon, hover_bg_color=HOVER_BG_COLOR)
+                button.cheevo_id = achievement
+                self.buttons.append(button)
+                y_offset += 70
+                if y_offset > 480:
+                    break
 
-        y_offset = 130 + self.scroll_y
-        self.buttons = []
-        for achievement in self.state.get_uploaded_achievements():
-            ach_title = self.state.get_uploaded_achievements()[achievement]["Title"]
-            game_title = self.state.get_uploaded_achievements()[achievement]["GameTitle"]
-            button_text = [ach_title, game_title]
-            button_icon = Icon(self.state, achievement, locked=False)
-            text_color = TEXT_COLOR_UNLOCKED
-            highlight_color = TEXT_COLOR_UNLOCKED
-            button = Button(button_text, (20, y_offset), [FONT, FONT_SMALL], text_color, highlight_color, centered=False, icon=button_icon, hover_bg_color=HOVER_BG_COLOR)
-            button.cheevo_id = achievement
-            self.buttons.append(button)
-            y_offset += 70
-            if y_offset > 480:
-                break
+            render_text('All achievements synchronized', (10, 10), FONT, TEXT_COLOR_LIGHT)
 
-        for i, button in enumerate(self.buttons):
-            button.set_hovering(i == self.selected_button_index)
-            if button.pos[1] > 55 and button.pos[1] < 370:
-                button.update(SCREEN)
+            for i, button in enumerate(self.buttons):
+                button.set_hovering(i == self.selected_button_index)
+                if 55 < button.pos[1] < 370:
+                    button.update(SCREEN)
 
-        pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 425), (640, 55)))
-        render_text(f"{self.selected_button_index+1}/{len(self.state.get_uploaded_achievements())}", (320, 450), FONT, TEXT_COLOR_LIGHT, centered=True)
+            pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 425), (640, 55)))
+            render_text(f"{self.selected_button_index + 1}/{len(self.state.get_uploaded_achievements())}", (320, 450),
+                        FONT, TEXT_COLOR_LIGHT, centered=True)
+            render_text("Use DPAD to navigate", (15, 435), FONT_SMALL, TEXT_COLOR_LIGHT)
+        except(Exception,):
+            render_text('RetroAchievements server is down', (10, 10), FONT, TEXT_COLOR_LIGHT)
+            pygame.draw.rect(SCREEN, BANNER_COLOR, pygame.Rect((0, 425), (640, 55)))
 
-        render_text("Use DPAD to navigate", (15, 435), FONT_SMALL, TEXT_COLOR_LIGHT)
         render_text("B to return", (15, 455), FONT_SMALL, TEXT_COLOR_LIGHT)
 
 
 class GlobalState:
     def __init__(self):
-        self.current_state = "SCROLL_CHEEVOS" 
+        self.current_state = "SCROLL_CHEEVOS"
         self.cheevos_token = None
         self.key_states = {
             pygame.K_UP: False,
@@ -460,8 +477,8 @@ class GlobalState:
         self.unmatched_dict = {}
         self.game_dict_cache = {}
         self.debug_string = 'Logging in...'
-        self.username = None 
-        self.password = None 
+        self.username = None
+        self.password = None
 
         # API key. Use your own for fewer dropped network requests (can be found in 
         # retroachievements.org/controlpanel.php, look for 'Web API Key')
@@ -469,12 +486,13 @@ class GlobalState:
         # replace with your own username if using your own API key
         self.api_username = 'ijustneedanapikey'
 
-        self.states = {}
-        self.states["ERROR"] = ErrorScreen(self)
-        self.states["MAIN_MENU"] = MainMenu(self)
-        self.states["SCROLL_CHEEVOS"] = ScrollCheevos(self)
-        self.states["SYNC_CHEEVOS"] = SyncAchievements(self)
-        self.states["LIST_CHEEVOS"] = ListAchievements(self)
+        self.states = {
+            "ERROR": ErrorScreen(self),
+            "MAIN_MENU": MainMenu(self),
+            "SCROLL_CHEEVOS": ScrollCheevos(self),
+            "SYNC_CHEEVOS": SyncAchievements(self),
+            "LIST_CHEEVOS": ListAchievements(self)
+        }
 
     def print_error(self, msg):
         print(msg)
@@ -498,10 +516,10 @@ class GlobalState:
                     for line in f:
                         if line.startswith('global.retroachievements.username'):
                             self.username = line.split('=')[1].strip()
-            except:
+            except(Exception,):
                 self.print_error(['Could not find retroachievements username in',
-                    BATOCERA_CONF_LOCATION,
-                    'either add it to the config file or hardcode it at the top of this script.'])
+                                  BATOCERA_CONF_LOCATION,
+                                  'either add it to the config file or hardcode it at the top of this script.'])
         return self.username
 
     def get_password(self):
@@ -513,10 +531,10 @@ class GlobalState:
                     for line in f:
                         if line.startswith('global.retroachievements.password'):
                             self.password = line.split('=')[1].strip()
-            except:
+            except(Exception,):
                 self.print_error(['Could not find retroachievements password in',
-                    BATOCERA_CONF_LOCATION,
-                    'either add it to the config file or hardcode it at the top of this script.'])
+                                  BATOCERA_CONF_LOCATION,
+                                  'either add it to the config file or hardcode it at the top of this script.'])
         return self.password
 
     def get_badgenum_from_cid(self, cheevo_id):
@@ -546,7 +564,7 @@ class GlobalState:
         if os.path.exists(icon_path):
             try:
                 icon_cache[cheevo_id] = pygame.image.load(icon_path)
-            except:
+            except(Exception,):
                 os.remove(icon_path)
 
         if not os.path.exists(icon_path):
@@ -567,10 +585,11 @@ class GlobalState:
             target_extension = ".png"
 
             try:
-                entries = os.listdir(target_dir)
+                entries = os.path.abspath(target_dir)
             except OSError as e:
                 self.print_error(['Error loading screenshot directory', target_dir, f'Error: {e}',
-                    'To use a different screenshot directory, change the location at the top of this file.'])
+                                  'To use a different screenshot directory, '
+                                  'change the location at the top of this file.'])
                 return []
 
             for entry in entries:
@@ -604,25 +623,29 @@ class GlobalState:
 
     def send_unlock_request(self, cheevo_id):
         url = 'https://retroachievements.org/dorequest.php'
-        params = {'u': self.get_username(), 'r': 'awardachievement', 
-                'a': cheevo_id, 't': self.get_token(), 'h': 0}
+        params = {'u': self.get_username(), 'r': 'awardachievement',
+                  'a': cheevo_id, 't': self.get_token(), 'h': 0}
         mheaders = {'User-Agent': '1.2.0'}
         response = requests.get(url, headers=mheaders, params=params)
         print(response.text)
 
     def get_uploaded_achievements(self, force_reload=False):
         if self.uploaded_achievements is None or force_reload:
-            url = f'https://retroachievements.org/API/API_GetUserRecentAchievements.php'
-            params = {'u': self.get_username(), 'z': self.api_username,
-                    'y': self.api_key, 'm': 10000000}
-            response = requests.get(url, params=params)
-            print(response.text)
-            achievements = json.loads(response.text)
-            cheevo_ids = [x['AchievementID'] for x in achievements]
-            cheevo_dict = {}
-            for i, cid in enumerate(cheevo_ids):
-                cheevo_dict[cid] = achievements[i]
-            self.uploaded_achievements = cheevo_dict
+            try:
+                url = f'https://retroachievements.org/API/API_GetUserRecentAchievements.php'
+                params = {'u': self.get_username(), 'z': self.api_username,
+                          'y': self.api_key, 'm': 10000000}
+                response = requests.get(url, params=params)
+                print(response.text)
+                achievements = json.loads(response.text)
+                cheevo_ids = [x['AchievementID'] for x in achievements]
+                cheevo_dict = {}
+                for i, cid in enumerate(cheevo_ids):
+                    cheevo_dict[cid] = achievements[i]
+                self.uploaded_achievements = cheevo_dict
+            except Exception as e:
+                print(f"RetroAchievements API down\n{str(e)}")
+                self.uploaded_achievements = None
 
         return self.uploaded_achievements
 
@@ -640,10 +663,10 @@ class GlobalState:
                     self.debug_string = f'Login successful'
                 else:
                     self.debug_string = f'Login error'
-            except:
+            except(Exception,):
                 self.print_error(['Failed RetroAchievements login!', '',
-                    f'username | password used: {self.get_username()} | {self.get_password()}',
-                    'Check you credentials in batocera.conf, or enter them manually in this file.'])
+                                  f'username | password used: {self.get_username()} | {self.get_password()}',
+                                  'Check your credentials in batocera.conf, or enter them manually in this file.'])
                 self.debug_string = f'Login error'
         return self.cheevos_token
 
@@ -661,10 +684,11 @@ def main():
     state = GlobalState()
 
     render_startscreen(state)
-    # check if we can login
+    # check if we can log in
     print(state.get_token())
 
-    state.unmatched_achievements = [x for x in state.get_unlocked_achievements() if x not in state.get_uploaded_achievements()]
+    state.unmatched_achievements = [x for x in state.get_unlocked_achievements() if
+                                    x not in state.get_uploaded_achievements()]
 
     while True:
         SCREEN.fill(BACKGROUND_COLOR)
@@ -680,6 +704,7 @@ def main():
 
         pygame.display.update()
         CLOCK.tick(FPS)
+
 
 if __name__ == "__main__":
     main()

--- a/sync_achievements.pygame
+++ b/sync_achievements.pygame
@@ -663,6 +663,10 @@ class GlobalState:
                     self.debug_string = f'Login successful'
                 else:
                     self.debug_string = f'Login error'
+            except requests.exceptions.RequestException:
+                self.print_error(['Failed RetroAchievements login!', '',
+                                  f'Please check that your device is connected to the internet.'])
+                self.debug_string = f'Network error'
             except(Exception,):
                 self.print_error(['Failed RetroAchievements login!', '',
                                   f'username | password used: {self.get_username()} | {self.get_password()}',


### PR DESCRIPTION
The application will crash if the RetroAchievements API returns a 503. 

The first API call is in `get_uploaded_achievements()`. I added a try/except block here, though I probably didn't need to actually.
When the call returns 503, `uploaded_achievements` does not return a valid dictionary, leading to a crash in `render()` under the `ListAchievements` class.

To resolve this I put the relevant code into a simple try/except block. When an exception occurs, the UI will display "RetroAchievements server is down" instead. I don't know how to change the state to escape the loop, so it keeps trying to hit the API until end user quits. This should probably be resolved.

On the line containing `entries = os.listdir(target_dir)`, I changed it to `entries = os.path.abspath(target_dir)` because I couldn't get it working in Windows otherwise. This change does not affect operation when tested on my RG35XXH

Added exception handling for when no network is detected, and providing a useful error message to end user.

Aside from that, I cleaned up some code to make it more standardized (my IDE was complaining)